### PR TITLE
Repl errors

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -35,6 +35,7 @@ func (e *Env) assign(varName string, value Object) {
 	if found, ok := e.values[varName]; ok {
 		if value.Type() != found.Type() {
 			RuntimeError(fmt.Sprintf("Cannot assign %s to %s type", string(value.Type()), string(found.Type())))
+			return
 		}
 		e.values[varName] = value
 	} else if e.parent != nil {

--- a/environment.go
+++ b/environment.go
@@ -26,8 +26,9 @@ func (e *Env) define(varName string, value Object) {
 	_, exists := e.values[varName]
 	if exists {
 		RuntimeError("Variable '" + varName + "' already initialized in this scope")
+	} else {
+		e.values[varName] = value
 	}
-	e.values[varName] = value
 }
 
 func (e *Env) assign(varName string, value Object) {
@@ -50,6 +51,5 @@ func (e *Env) get(varName string) Object {
 		return e.parent.get(varName)
 	}
 
-	RuntimeError("Undefined variable: '" + varName + "'")
-	return NIL //unreachable code
+	return RuntimeError("Undefined variable: '" + varName + "'")
 }

--- a/interpreter.go
+++ b/interpreter.go
@@ -51,7 +51,6 @@ func (i *Interpreter) visitExprStmt(e ExprStmt) {
 func (i *Interpreter) visitVarDeclaration(vd VarDeclaration) {
 	val := i.Evaluate(vd.initializer)
 	if !IsButterError(val) && CheckVarType(vd.tokenType, val) {
-		fmt.Println(CheckVarType(vd.tokenType, val))
 		i.env.define(vd.identifier.literal, val)
 	}
 }

--- a/interpreter.go
+++ b/interpreter.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 )
 
+var hadRuntimeError bool = false
+
 /*The Interpreter struct which merely holds a bunch of methods */
 type Interpreter struct {
 	env    Env
@@ -24,6 +26,9 @@ func (i *Interpreter) Interpret(stmts []Stmt, repl bool) {
 	i.isRepl = repl
 	for _, stmt := range stmts {
 		i.Execute(stmt)
+		if hadRuntimeError {
+			break
+		}
 	}
 }
 
@@ -39,14 +44,15 @@ func (i *Interpreter) Evaluate(e Expr) Object {
 
 func (i *Interpreter) visitExprStmt(e ExprStmt) {
 	val := i.Evaluate(e.expr)
-	if i.isRepl && val != NIL {
+	if i.isRepl && val != NIL && !IsButterError(val) {
 		fmt.Println(Stringify(val))
 	}
 }
 func (i *Interpreter) visitVarDeclaration(vd VarDeclaration) {
 	val := i.Evaluate(vd.initializer)
-	CheckVarType(vd.tokenType, val)
-	i.env.define(vd.identifier.literal, val)
+	if val.Type() != ERROROBJ && CheckVarType(vd.tokenType, val) {
+		i.env.define(vd.identifier.literal, val)
+	}
 }
 func (i *Interpreter) visitErrorStmt(e ErrorStmt) {
 	fmt.Println(e.message)
@@ -55,7 +61,9 @@ func (i *Interpreter) visitErrorStmt(e ErrorStmt) {
 /*visitAssign visits an assignment operation and then saves it to the environment variable */
 func (i *Interpreter) visitAssign(a Assign) Object {
 	val := i.Evaluate(a.initializer)
-	i.env.assign(a.identifier.literal, val)
+	if !IsButterError(val) {
+		i.env.assign(a.identifier.literal, val)
+	}
 	return NIL
 }
 
@@ -67,11 +75,16 @@ func (i *Interpreter) visitVariable(v Variable) Object {
 /*visitPrint evaluates the expr contained within a print object and then prints that */
 func (i *Interpreter) visitPrint(p Print) {
 	result := i.Evaluate(p.expr)
-	fmt.Println(Stringify(result))
+	if !IsButterError(result) {
+		fmt.Println(Stringify(result))
+	}
 }
 
 func (i *Interpreter) visitIf(ifStmt If) {
 	condition := i.Evaluate(ifStmt.condition)
+	if IsButterError(condition) {
+		return
+	}
 	if res, ok := condition.(Boolean); ok {
 		if res.Value {
 			i.Execute(ifStmt.ifTrue)
@@ -85,9 +98,11 @@ func (i *Interpreter) visitIf(ifStmt If) {
 
 func (i *Interpreter) visitWhile(w While) {
 	condition := i.Evaluate(w.condition)
+
 	condBool, ok := condition.(Boolean)
 	if !ok {
 		RuntimeError("Cannot use non boolean value in while condition")
+		return
 	}
 	for condBool.Value {
 		i.Execute(w.body)
@@ -105,6 +120,9 @@ func (i *Interpreter) visitBlock(b Block) {
 	defer func() { i.env = prevEnv }()
 	for _, stmt := range b.stmts {
 		i.Execute(stmt)
+		if hadRuntimeError {
+			break
+		}
 	}
 }
 
@@ -150,23 +168,22 @@ func (i *Interpreter) visitBinary(b Binary) Object {
 		switch b.operator.Type {
 		case PLUS:
 			return String{leftString.Value + Stringify(rightObj)}
-		default:
-			RuntimeError("string does not support '" + b.operator.Type.String() + "' operator")
 		}
 	}
-	RuntimeError("Mismatched operands: '" + string(leftObj.Type()) + "' and '" + string(rightObj.Type()) + "'")
-	return NIL
+	return RuntimeError(fmt.Sprintf("Mismatched operands -> '%s' does not support '%s' operation on '%s'", string(leftObj.Type()), b.operator.Type, string(rightObj.Type())))
 }
 
 func (i *Interpreter) visitUnary(u Unary) Object {
 	result := i.Evaluate(u.right)
-
+	if IsButterError(result) {
+		return result
+	}
 	switch u.operator.Type {
 	case BANG:
 		if val, ok := result.(Boolean); ok {
 			return Boolean{!val.Value}
 		}
-		RuntimeError("Cannot negate non-boolean object")
+		return RuntimeError("Cannot negate non-boolean object")
 	case MINUS:
 		if val, ok := result.(Integer); ok {
 			return Integer{-val.Value}
@@ -174,9 +191,9 @@ func (i *Interpreter) visitUnary(u Unary) Object {
 		if val, ok := result.(Float); ok {
 			return Float{-val.Value}
 		}
-		RuntimeError("Cannot have negative non-number type")
+		return RuntimeError("Cannot have negative non-number type")
 	}
-	return NIL
+	return RuntimeError("Unknown unary operator")
 }
 
 /*visitLiteral return sthe underlying object value of a literal */
@@ -193,7 +210,7 @@ func EvaluateFloat(left Float, right Float, operator Token) Object {
 		return Float{left.Value - right.Value}
 	case DIV:
 		if right.Value == 0 {
-			RuntimeError("Divide by zero error")
+			return RuntimeError("Divide by zero error")
 		} else if left.Value == 0 {
 			return Float{0}
 		}
@@ -219,8 +236,7 @@ func EvaluateFloat(left Float, right Float, operator Token) Object {
 	case LESSEQUAL:
 		return Boolean{left.Value <= right.Value}
 	default:
-		RuntimeError(fmt.Sprintf("Unsupported operation (%s) on values of type 'FLOAT'", operator.Type.String()))
-		return NIL
+		return RuntimeError(fmt.Sprintf("Unsupported operation (%s) on values of type 'FLOAT'", operator.Type.String()))
 	}
 }
 
@@ -233,14 +249,14 @@ func EvaluateInt(left Integer, right Integer, operator Token) Object {
 		return Integer{left.Value - right.Value}
 	case DIV:
 		if right.Value == 0 {
-			RuntimeError("Divide by zero error")
+			return RuntimeError("Divide by zero error")
 		} else if left.Value == 0 {
 			return Integer{0}
 		}
 		return Integer{left.Value / right.Value}
 	case MOD:
 		if right.Value == 0 {
-			RuntimeError("Module by zero error")
+			return RuntimeError("Module by zero error")
 		}
 		return Integer{left.Value % right.Value}
 	case MULT:
@@ -264,8 +280,7 @@ func EvaluateInt(left Integer, right Integer, operator Token) Object {
 	case LESSEQUAL:
 		return Boolean{left.Value <= right.Value}
 	default:
-		RuntimeError(fmt.Sprintf("Unsupported operation (%s) on values of type 'INTEGER'", operator.Type.String()))
-		return NIL
+		return RuntimeError(fmt.Sprintf("Unsupported operation (%s) on values of type 'INTEGER'", operator.Type.String()))
 	}
 }
 
@@ -281,8 +296,7 @@ func EvaluateBoolean(left Boolean, right Boolean, operator Token) Object {
 	case BANGEQUAL:
 		return Boolean{left.Value != right.Value}
 	default:
-		RuntimeError("Unsupported operation on values of type 'BOOLEAN'")
-		return NIL
+		return RuntimeError("Unsupported operation on values of type 'BOOLEAN'")
 	}
 }
 
@@ -321,25 +335,40 @@ func CheckVarType(varType Token, val Object) bool {
 	case INTTYPE:
 		if val.Type() != INTEGEROBJ {
 			RuntimeError("TypeError -> cannot assign " + string(val.Type()) + " to int type")
+			return false
 		}
 		return true
 	case FLOATTYPE:
 		if val.Type() != FLOATOBJ {
 			RuntimeError("TypeError -> cannot assign " + string(val.Type()) + " to float type")
+			return false
 		}
 		return true
 	case BOOLTYPE:
 		if val.Type() != BOOLEANOBJ {
 			RuntimeError("TypeError -> cannot assign " + string(val.Type()) + " to bool type")
+			return false
 		}
 		return true
 	case STRINGTYPE:
 		if val.Type() != STRINGOBJ {
 			RuntimeError("TypeError -> cannot assign " + string(val.Type()) + " to string type")
+			return false
 		}
 		return true
 	default:
 		RuntimeError("TypeError -> Unknown assignment type")
 	}
 	return false
+}
+
+func IsButterError(o Object) bool {
+	return o.Type() == ERROROBJ
+}
+
+/*RuntimeError stops the execution of the program when it encounters invalid operations duringn the running of the program */
+func RuntimeError(message string) ButterError {
+	ReportError("RUNTIME_ERROR: " + message)
+	hadRuntimeError = true
+	return ButterError{}
 }

--- a/interpreter.go
+++ b/interpreter.go
@@ -50,7 +50,8 @@ func (i *Interpreter) visitExprStmt(e ExprStmt) {
 }
 func (i *Interpreter) visitVarDeclaration(vd VarDeclaration) {
 	val := i.Evaluate(vd.initializer)
-	if val.Type() != ERROROBJ && CheckVarType(vd.tokenType, val) {
+	if !IsButterError(val) && CheckVarType(vd.tokenType, val) {
+		fmt.Println(CheckVarType(vd.tokenType, val))
 		i.env.define(vd.identifier.literal, val)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -69,11 +69,7 @@ func RunPrompt() {
 		}
 		in, err := reader.ReadString('\n')
 		if err == io.EOF {
-			fmt.Printf("\n REPL detected EOF. exiting...")
-			os.Exit(1)
-		} else if err != nil {
-			fmt.Printf("\n Unable to read line. exiting...")
-			os.Exit(1)
+			os.Exit(0)
 		}
 		input += in //concatenate the new input onto the previous input
 		if len(in)-2 == 0 || MatchingBraces(input) {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 )
@@ -66,7 +67,14 @@ func RunPrompt() {
 			//if we are in a block, match the indentation of above
 			fmt.Print("  ")
 		}
-		in, _ := reader.ReadString('\n')
+		in, err := reader.ReadString('\n')
+		if err == io.EOF {
+			fmt.Printf("\n REPL detected EOF. exiting...")
+			os.Exit(1)
+		} else if err != nil {
+			fmt.Printf("\n Unable to read line. exiting...")
+			os.Exit(1)
+		}
 		input += in //concatenate the new input onto the previous input
 		if len(in)-2 == 0 || MatchingBraces(input) {
 			//if the newline is empty, or all the braces have been matched up run the input

--- a/main.go
+++ b/main.go
@@ -81,6 +81,10 @@ func RunPrompt() {
 func Run(source string, repl bool) {
 	tokenizer := NewTokenizer(source)
 	tokens := tokenizer.Tokenize()
+	if hadError {
+		return
+	}
+	PrintTokens(tokens)
 	parser := NewParser(tokens)
 	stmts := parser.Parse()
 
@@ -120,5 +124,5 @@ func RuntimeError(message string) {
 /*ReportError stops execution of the program with a panic-like error message */
 func ReportError(message string) {
 	fmt.Fprintf(os.Stderr, message+"\n")
-	hadError = false
+	hadError = true
 }

--- a/main.go
+++ b/main.go
@@ -84,7 +84,6 @@ func Run(source string, repl bool) {
 	if hadError {
 		return
 	}
-	PrintTokens(tokens)
 	parser := NewParser(tokens)
 	stmts := parser.Parse()
 

--- a/main.go
+++ b/main.go
@@ -115,11 +115,6 @@ func MatchingBraces(input string) bool {
 	return left_brace == right_brace
 }
 
-/*RuntimeError stops the execution of the program when it encounters invalid operations duringn the running of the program */
-func RuntimeError(message string) {
-	ReportError("RUNTIME_ERROR: " + message)
-}
-
 /*ReportError stops execution of the program with a panic-like error message */
 func ReportError(message string) {
 	fmt.Fprintf(os.Stderr, message+"\n")

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 )
 
 var VERSION string = "0.1"
+var hadError bool = false
 
 /*Settings struct Contains the settings for the current interpreter */
 type Settings struct {
@@ -41,9 +42,15 @@ func main() {
 /*RunFile Reads file into biffer and then runs it */
 func RunFile(s Settings) {
 	inputBytes, err := ioutil.ReadFile(s.fileLoc)
-	CheckError(err)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: Unable to read file '%s'\n", s.fileLoc)
+		os.Exit(1)
+	}
 	inputString := string(inputBytes) + "\r\n"
 	Run(inputString, false)
+	if hadError {
+		os.Exit(1)
+	}
 }
 
 /*RunPrompt runs the REPL and feeds input to the run method as it comes in  */
@@ -66,6 +73,7 @@ func RunPrompt() {
 			Run(input, true)
 			input = "" //reset the input for the next run
 		}
+		hadError = false
 	}
 }
 
@@ -75,6 +83,11 @@ func Run(source string, repl bool) {
 	tokens := tokenizer.Tokenize()
 	parser := NewParser(tokens)
 	stmts := parser.Parse()
+
+	if hadError {
+		return
+	}
+
 	interpreter.Interpret(stmts, repl)
 }
 
@@ -93,31 +106,10 @@ func MatchingBraces(input string) bool {
 			}
 			if b == '}' {
 				right_brace++
-				if right_brace > left_brace {
-					//if a right brace has been seen without a left brace coming before it
-					ParseError(-1, "'}' found without matching '{'")
-				}
 			}
 		}
 	}
 	return left_brace == right_brace
-}
-
-/*CheckError checks to see if an error has been reported from a function */
-func CheckError(err error) {
-	if err != nil {
-		ParseError(-1, err.Error())
-	}
-}
-
-/*ParseError Reports an error during the initial tokenization and parsing of the input */
-func ParseError(line int, message string) {
-	var lineMessage string
-	if line != -1 {
-		lineMessage = fmt.Sprintf(" [line %d]", line)
-	}
-	errorMessage := fmt.Sprintf("PARSE_ERROR%s: %s", lineMessage, message)
-	ReportError(errorMessage)
 }
 
 /*RuntimeError stops the execution of the program when it encounters invalid operations duringn the running of the program */
@@ -128,5 +120,5 @@ func RuntimeError(message string) {
 /*ReportError stops execution of the program with a panic-like error message */
 func ReportError(message string) {
 	fmt.Fprintf(os.Stderr, message+"\n")
-	os.Exit(1)
+	hadError = false
 }

--- a/object.go
+++ b/object.go
@@ -9,6 +9,7 @@ const (
 	BOOLEANOBJ ObjType = "bool"
 	STRINGOBJ  ObjType = "string"
 	NILOBJ     ObjType = "(nil)"
+	ERROROBJ   ObjType = "error"
 )
 
 /*Object defines a common object interface which all variable types will implement */
@@ -67,3 +68,10 @@ func (n Nil) Type() ObjType {
 
 /*NIL is a singleton which all nil objects will reference */
 var NIL Nil
+
+/*Error is a value that will be checked for in the parser to determine when to synchronize */
+type ButterError struct{}
+
+func (e ButterError) Type() ObjType {
+	return ERROROBJ
+}

--- a/parser.go
+++ b/parser.go
@@ -358,7 +358,7 @@ func (p *Parser) CheckEndline() bool {
 /*Synchronize returns the parser to the beginning of a statement, where it can hopefully continue parsing input */
 func (p *Parser) Synchronize() {
 	for !p.Match(NEWLINE) && !p.AtEnd() {
-
+		p.Advance()
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"strconv"
 )
 
+var hadParseError bool = false
+
 /*Parser struct contains helpful methods for recursive descvent parsing, as well as keeping track of the
-  token list, amnd token currently being processed */
+token list, amnd token currently being processed */
 type Parser struct {
 	tokens  []Token
 	current int
@@ -23,9 +26,15 @@ func (p *Parser) Parse() []Stmt {
 	var statements []Stmt
 	for !p.AtEnd() {
 		//Eat newlines before statements
-		statements = append(statements, p.Declaration())
-		//Eat new lines after statements
-		p.IgnoreNewlines()
+		decl := p.Declaration()
+		if hadParseError {
+			p.Synchronize()
+			hadParseError = false
+		} else {
+			statements = append(statements, decl)
+			//Eat new lines after statements
+			p.IgnoreNewlines()
+		}
 	}
 	return statements
 }
@@ -245,7 +254,9 @@ func (p *Parser) Literal() Expr {
 	if p.Match(INT) {
 		prev := p.Previous()
 		integer, err := strconv.Atoi(prev.literal)
-		CheckError(err)
+		if err != nil {
+			ParseError(p.Previous().line, "Unable to parse int")
+		}
 		return Literal{Integer{integer}}
 	}
 	if p.Match(FLOAT) {
@@ -342,4 +353,22 @@ func (p *Parser) CheckEndline() bool {
 	}
 	ParseError(p.Current().line, "Expected new line after statement")
 	return false
+}
+
+/*Synchronize returns the parser to the beginning of a statement, where it can hopefully continue parsing input */
+func (p *Parser) Synchronize() {
+	for !p.Match(NEWLINE) && !p.AtEnd() {
+
+	}
+}
+
+/*ParseError Reports an error during the initial tokenization and parsing of the input */
+func ParseError(line int, message string) {
+	var lineMessage string
+	if line != -1 {
+		lineMessage = fmt.Sprintf(" [line %d]", line)
+	}
+	errorMessage := fmt.Sprintf("PARSE_ERROR%s: %s", lineMessage, message)
+	ReportError(errorMessage)
+	hadParseError = true
 }

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -289,6 +289,7 @@ func (t *Tokenizer) Tokenize() []Token {
 				t.Advance()
 				if t.AtEnd() {
 					TokenError(t.lineNo, "Unclosed multiline comment")
+					break
 				}
 			} else {
 				t.AddToken(DIV, "")
@@ -338,6 +339,7 @@ func (t *Tokenizer) Tokenize() []Token {
 				t.Advance()
 				if t.AtEnd() {
 					TokenError(t.lineNo, "Unclosed string literal")
+					break
 				}
 			}
 			t.AddToken(STRING, t.inputString[t.begTok+1:t.cursorLoc-1])

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -244,7 +244,7 @@ func NewTokenizer(inputString string) Tokenizer {
 	reserved["float"] = FLOATTYPE
 	reserved["bool"] = BOOLTYPE
 	reserved["string"] = STRINGTYPE
-	return Tokenizer{inputString, []Token{}, 0, 0, '0', 0}
+	return Tokenizer{inputString, []Token{}, 0, 0, '0', 1}
 }
 
 /*Tokenize takes in an entire program as a string argument and parses it into tokens
@@ -288,7 +288,7 @@ func (t *Tokenizer) Tokenize() []Token {
 				t.Advance()
 				t.Advance()
 				if t.AtEnd() {
-					ParseError(t.lineNo, "Unclosed multiline comment")
+					TokenError(t.lineNo, "Unclosed multiline comment")
 				}
 			} else {
 				t.AddToken(DIV, "")
@@ -313,7 +313,7 @@ func (t *Tokenizer) Tokenize() []Token {
 			if t.Match('=') {
 				t.AddToken(EQUALEQUAL, "")
 			} else {
-				ParseError(t.lineNo, "Expect '=' after '='")
+				TokenError(t.lineNo, "Expect '=' after '='")
 			}
 		case '>':
 			if t.Match('=') {
@@ -331,13 +331,13 @@ func (t *Tokenizer) Tokenize() []Token {
 			if t.Match('=') {
 				t.AddToken(ASSIGN, "")
 			} else {
-				ParseError(t.lineNo, "Expect '=' after ':'")
+				TokenError(t.lineNo, "Expect '=' after ':'")
 			}
 		case '"':
 			for !t.Match('"') {
 				t.Advance()
 				if t.AtEnd() {
-					ParseError(t.lineNo, "Unclosed string literal")
+					TokenError(t.lineNo, "Unclosed string literal")
 				}
 			}
 			t.AddToken(STRING, t.inputString[t.begTok+1:t.cursorLoc-1])
@@ -347,7 +347,7 @@ func (t *Tokenizer) Tokenize() []Token {
 			} else if IsAlpha(cursor) {
 				t.IdentifierOrReserved()
 			} else {
-				ParseError(t.lineNo+1, fmt.Sprintf("near -> '%c'", t.inputString[t.cursorLoc-1]))
+				TokenError(t.lineNo, fmt.Sprintf("near -> '%c'", t.inputString[t.cursorLoc-1]))
 			}
 		}
 	}
@@ -447,4 +447,8 @@ func (t *Tokenizer) AddToken(tokenType TokenType, literal string) {
 	token := Token{tokenType, literal, t.lineNo}
 	t.begTok = t.cursorLoc
 	t.tokens = append(t.tokens, token)
+}
+
+func TokenError(line int, message string) {
+	ReportError(fmt.Sprintf("TOKEN_ERROR [line %d]: %s", line, message))
 }


### PR DESCRIPTION
- Completely changed way ParseErrors and RuntimeErrors are handled so as not to crash REPL
- Created a RuntimeError object type that is caught to prevent improper assignment
- Check for errors after tokenization and parsing in Run function to insure no bad code gets run
- Now checks for EOF and other signals immediately after reading the file in REPL

Closes issue #9 and #8 and #4 and #11 